### PR TITLE
fix: cannot import TestClient

### DIFF
--- a/example/test/db.test.ts
+++ b/example/test/db.test.ts
@@ -1,5 +1,5 @@
 import { sql } from "@orkestro/lib-pg";
-import { TestClient } from "@orkestro/lib-pg/test";
+import { TestClient } from "@orkestro/lib-pg";
 import { expect } from "chai";
 
 describe("test example", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export { migrateSchema } from "./migration";
 export { readSqlFileSync, readSqlFilesInDirSync } from "./sql-files";
 export { QueryConfig } from "./types";
 export { generateSchemaTypeDeclarations } from "./schema-types";
+export { TestClient } from "./test-utils";

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -71,11 +71,7 @@ export class TestClient implements Client {
         if (this.pgClient) {
           await this.pgClient.query("begin transaction");
           await this.pgClient.query("savepoint clean_state");
-          this.db = new ActiveTransactionClient(
-            this.pgClient,
-            console,
-            Date.now().toString()
-          );
+          this.db = new ActiveTransactionClient(this.pgClient, console);
         }
       });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,1 +1,0 @@
-export { TestClient } from "./utils";


### PR DESCRIPTION
Move test/utils to src/test-utils

This is because `test/` files are not compiled with tsc and so it's not possible to import them in projects using lib-pg


`test-utils.ts` file does not depend on any libraries on import time. Only if trying to instantiate it `new TestClient()` - if not running inside test it will fail because of `before/after` being undefined. I think it's ok to ship this on `lib-pg` index export for convenient access



Error described her:
https://github.com/TypeStrong/ts-node/issues/158#:~:text=ts-node%20cannot%20import%20pure%20typescript%20npm%20module%20inside,Chatie%2Fserver%20that%20referenced%20this%20issue%20Jul%2026%2C%202016

and when used as `import {TestClient} from "@orkestro/pg-lib"` we get error
```
export { TestClient } from "./utils";
^^^^^^
SyntaxError: Unexpected token 'export'
```