### PR TITLE
fix: dont rewrite error in transactions

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -166,7 +166,6 @@ export class ActiveClient implements Client {
   ): Promise<T> {
     const { pgClient } = this;
     const txnId = uuid();
-    const transactionError = new Error(`Transaction error`);
     const start = Date.now();
     activeProcessTransactions++;
 
@@ -192,15 +191,13 @@ export class ActiveClient implements Client {
           return result;
         })
         .catch(async (error) => {
-          logger.error("Transaction failed", error);
-
           try {
             await pgClient.query("rollback");
+            logger.info("Transaction rolled back");
           } catch (error) {
             logger.error(`Failed to rollback transaction: `, error);
           }
-
-          throw transactionError;
+          throw error;
         });
     } finally {
       activeProcessTransactions--;

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -95,8 +95,8 @@ describe("db.sql.client", () => {
         [
           "[txn:query1:<uuid>] Starting transaction",
           "[txn:query1:<uuid>] Query(fail): failed (42601)",
-          "[txn:query1:<uuid>] Transaction failed",
           "[txn:query1:<uuid>] Query(select 1): failed (25P02)",
+          "[txn:query1:<uuid>] Transaction rolled back",
           "[txn:query2:<uuid>] Starting transaction",
           "[txn:query2:<uuid>] Query(select 1): SELECT 1",
           "[txn:query2:<uuid>] Query(select 2): SELECT 1",


### PR DESCRIPTION
We have used following pattern:

```
db.transaction(db => {
   ...

   if(...) {
      throw ConsistencyError()
   }
})
```

however `.transaction()` would capture error and override it with different instance