### PR TITLE
Feat(ORK-1223): Reduce the amount of query logs using an env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orkestro17/lib-pg",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -5,6 +5,7 @@ import { testPool } from "./config"
 import { sql } from "../src/tag"
 import { Logger } from "../src/types"
 
+process.env.ENABLE_QUERY_LOGS = "true"
 describe("db.sql.client", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const logs: (string | any)[] = []
@@ -29,73 +30,123 @@ describe("db.sql.client", () => {
     logs.splice(0)
   })
 
-  describe("run()", () => {
-    it("executed query and logs duration", async () => {
-      const result = await db.run(sql`select pg_sleep(0.055)`)
-      eq(logs[0][0], "Query(select pg_sleep(0.055)): SELECT 1")
-      eq(logs[0][1].duration >= 50, true, logs[0][1].duration)
-      eq(result, [{ pg_sleep: "" }])
+  describe("When query logs are enabled", () => {
+    before(() => {
+      process.env.ENABLE_QUERY_LOGS = "true"
     })
 
-    it("failed query produces informative stacktrace", async () => {
-      try {
-        await db.run(sql`syntaxError`).then(() => {
-          throw new Error("Query did not throw error")
-        })
-      } catch (e) {
-        const lines = (e as Error).stack?.split("\n") || []
-        eq(lines[0], 'Error: syntaxError [errcode: 42601] syntax error at or near "syntaxError" ')
-        eq(lines.filter((row) => row.indexOf("client.test.js:24")).length > 0, true)
-      }
+    after(() => {
+      process.env.ENABLE_QUERY_LOGS = undefined
+    })
+
+    describe("run()", () => {
+      it("executed query and logs duration", async () => {
+        const result = await db.run(sql`select pg_sleep(0.055)`)
+        eq(logs[0][0], "Query(select pg_sleep(0.055)): SELECT 1")
+        eq(logs[0][1].duration >= 50, true, logs[0][1].duration)
+        eq(result, [{ pg_sleep: "" }])
+      })
+
+      it("failed query produces informative stacktrace", async () => {
+        try {
+          await db.run(sql`syntaxError`).then(() => {
+            throw new Error("Query did not throw error")
+          })
+        } catch (e) {
+          const lines = (e as Error).stack?.split("\n") || []
+          eq(lines[0], 'Error: syntaxError [errcode: 42601] syntax error at or near "syntaxError" ')
+          eq(lines.filter((row) => row.indexOf("client.test.js:24")).length > 0, true)
+        }
+      })
+    })
+
+    describe("transaction()", () => {
+      it("executes multiple queries", async () => {
+        const result = await db.transaction("testTransaction", (transaction) =>
+          Promise.all([transaction.run(sql`select 1 as a`), transaction.run(sql`select 2 as b`)])
+        )
+        eq(result, [[{ a: 1 }], [{ b: 2 }]])
+        eq(
+          logs.map((row) => row[0]),
+          [
+            "[txn:testTransaction:<uuid>] Starting transaction",
+            "[txn:testTransaction:<uuid>] Query(select 1 as a): SELECT 1",
+            "[txn:testTransaction:<uuid>] Query(select 2 as b): SELECT 1",
+            "[txn:testTransaction:<uuid>] Transaction committed",
+          ]
+        )
+      })
+
+      it("releases client on error", async () => {
+        const query1 = db
+          .transaction("query1", (transaction) =>
+            Promise.all([transaction.run(sql`fail`), transaction.run(sql`select 1`)])
+          )
+          .catch((e) => e)
+
+        const query2 = db
+          .transaction("query2", (transaction) =>
+            Promise.all([transaction.run(sql`select 1`), transaction.run(sql`select 2`)])
+          )
+          .catch((e) => e)
+
+        await query1
+        await query2
+
+        eq(
+          logs.map((args) => args[0]),
+          [
+            "[txn:query1:<uuid>] Starting transaction",
+            "[txn:query1:<uuid>] Query(fail): failed (42601)",
+            "[txn:query1:<uuid>] Query(select 1): failed (25P02)",
+            "[txn:query1:<uuid>] Transaction rolled back for error: ",
+            "[txn:query2:<uuid>] Starting transaction",
+            "[txn:query2:<uuid>] Query(select 1): SELECT 1",
+            "[txn:query2:<uuid>] Query(select 2): SELECT 1",
+            "[txn:query2:<uuid>] Transaction committed",
+          ]
+        )
+      })
     })
   })
 
-  describe("transaction()", () => {
-    it("executes multiple queries", async () => {
-      const result = await db.transaction("testTransaction", (transaction) =>
-        Promise.all([transaction.run(sql`select 1 as a`), transaction.run(sql`select 2 as b`)])
-      )
-      eq(result, [[{ a: 1 }], [{ b: 2 }]])
-      eq(
-        logs.map((row) => row[0]),
-        [
-          "[txn:testTransaction:<uuid>] Starting transaction",
-          "[txn:testTransaction:<uuid>] Query(select 1 as a): SELECT 1",
-          "[txn:testTransaction:<uuid>] Query(select 2 as b): SELECT 1",
-          "[txn:testTransaction:<uuid>] Transaction committed",
-        ]
-      )
+  describe("When query logs are disabled", () => {
+    before(() => {
+      process.env.ENABLE_QUERY_LOGS = "anything-but-true"
     })
 
-    it("releases client on error", async () => {
-      const query1 = db
-        .transaction("query1", (transaction) =>
-          Promise.all([transaction.run(sql`fail`), transaction.run(sql`select 1`)])
+    after(() => {
+      process.env.ENABLE_QUERY_LOGS = undefined
+    })
+
+    describe("run()", () => {
+      it("does not log query and duration", async () => {
+        const result = await db.run(sql`select pg_sleep(0.055)`)
+        eq(logs.length, 0)
+        eq(result, [{ pg_sleep: "" }])
+      })
+
+      it("failed query produces informative stacktrace", async () => {
+        try {
+          await db.run(sql`syntaxError`).then(() => {
+            throw new Error("Query did not throw error")
+          })
+        } catch (e) {
+          const lines = (e as Error).stack?.split("\n") || []
+          eq(lines[0], 'Error: syntaxError [errcode: 42601] syntax error at or near "syntaxError" ')
+          eq(lines.filter((row) => row.indexOf("client.test.js:24")).length > 0, true)
+        }
+      })
+    })
+
+    describe("transaction()", () => {
+      it("does not log query and duration", async () => {
+        const result = await db.transaction("testTransaction", (transaction) =>
+          Promise.all([transaction.run(sql`select 1 as a`), transaction.run(sql`select 2 as b`)])
         )
-        .catch((e) => e)
-
-      const query2 = db
-        .transaction("query2", (transaction) =>
-          Promise.all([transaction.run(sql`select 1`), transaction.run(sql`select 2`)])
-        )
-        .catch((e) => e)
-
-      await query1
-      await query2
-
-      eq(
-        logs.map((args) => args[0]),
-        [
-          "[txn:query1:<uuid>] Starting transaction",
-          "[txn:query1:<uuid>] Query(fail): failed (42601)",
-          "[txn:query1:<uuid>] Query(select 1): failed (25P02)",
-          "[txn:query1:<uuid>] Transaction rolled back for error: ",
-          "[txn:query2:<uuid>] Starting transaction",
-          "[txn:query2:<uuid>] Query(select 1): SELECT 1",
-          "[txn:query2:<uuid>] Query(select 2): SELECT 1",
-          "[txn:query2:<uuid>] Transaction committed",
-        ]
-      )
+        eq(result, [[{ a: 1 }], [{ b: 2 }]])
+        eq(logs.length, 0)
+      })
     })
   })
 


### PR DESCRIPTION
In a day, around 1.5 logs are uploaded to GCP
just to log the queries we are running, ~75% of them are debug logs we can avoid

<img width="1842" alt="Captura de pantalla 2025-05-07 a las 12 34 41" src="https://github.com/user-attachments/assets/b9a5a230-2592-45ce-b04f-8330aeee74a1" />


This should enable services to decide whether they need to log that or not (Off by default)